### PR TITLE
Preserve inline styles when using byRow

### DIFF
--- a/jquery.matchHeight.js
+++ b/jquery.matchHeight.js
@@ -13,8 +13,8 @@
         _updateTimeout = -1;
 
     /*
-    *  _rows 
-    *  utility function returns array of jQuery selections representing each row 
+    *  _rows
+    *  utility function returns array of jQuery selections representing each row
     *  (as displayed after float wrapping applied by browser)
     */
 
@@ -131,7 +131,7 @@
                 var $that = $(this),
                     display = $that.css('display') === 'inline-block' ? 'inline-block' : 'block';
 
-                $that.css({
+                $that.data('original_style', $that.attr('style')).css({
                     'display': display,
                     'padding-top': '0',
                     'padding-bottom': '0',
@@ -144,14 +144,10 @@
             // get the array of rows (based on element top position)
             rows = _rows($elements);
 
-            // revert the temporary forced style
-            $elements.css({
-                'display': '',
-                'padding-top': '',
-                'padding-bottom': '',
-                'border-top-width': '',
-                'border-bottom-width': '',
-                'height': ''
+            $elements.each(function() {
+                var $that = $(this);
+
+                $that.attr('style', $that.data('original_style'));
             });
         }
 
@@ -213,7 +209,7 @@
     *  $.fn.matchHeight._applyDataApi
     *  applies matchHeight to all elements with a data-match-height attribute
     */
-   
+
     $.fn.matchHeight._applyDataApi = function() {
         var groups = {};
 
@@ -234,7 +230,7 @@
         });
     };
 
-    /* 
+    /*
     *  $.fn.matchHeight._update
     *  updates matchHeight on all current groups with their correct options
     */
@@ -246,7 +242,7 @@
     };
 
     $.fn.matchHeight._update = function(throttle, event) {
-        // prevent update if fired from a resize event 
+        // prevent update if fired from a resize event
         // where the viewport width hasn't actually changed
         // fixes an event looping bug in IE8
         if (event && event.type === 'resize') {
@@ -267,7 +263,7 @@
         }
     };
 
-    /* 
+    /*
     *  bind events
     */
 
@@ -275,12 +271,12 @@
     $($.fn.matchHeight._applyDataApi);
 
     // update heights on load and resize events
-    $(window).bind('load', function(event) { 
+    $(window).bind('load', function(event) {
         $.fn.matchHeight._update();
     });
 
     // throttled update heights on resize events
-    $(window).bind('resize orientationchange', function(event) { 
+    $(window).bind('resize orientationchange', function(event) {
         $.fn.matchHeight._update(true, event);
     });
 


### PR DESCRIPTION
When using byRow inline padding and border styles were being removed. This fixes the issue.
