### PR TITLE
cache original display property

### DIFF
--- a/jquery.matchHeight.js
+++ b/jquery.matchHeight.js
@@ -153,6 +153,10 @@
 
         // temporarily must force hidden parents visible
         var $hiddenParents = $elements.parents().filter(':hidden');
+        // cache original display attribute
+        $hiddenParents.each(function() {
+            $(this).attr('data-display-cache', $(this).css('display'))
+        });
         $hiddenParents.css('display', 'block');
 
         // get rows if using byRow, otherwise assume one row
@@ -232,8 +236,10 @@
             });
         });
 
-        // revert hidden parents
-        $hiddenParents.css('display', '');
+        // revert hidden parents from cache
+        $hiddenParents.each(function() {
+            $(this).css('display', $(this).attr('data-original-display'))
+        });
 
         // restore scroll position if enabled
         if (matchHeight._maintainScroll)


### PR DESCRIPTION
We ran into problems when using matchHeight.js with elements where the display property was set using inline css (a 'style' attribute). The hidden elements would have their display property removed when matchHeight triggered or on resize.

This patch caches the original display property and retrieves it from cache after the calculations has been done. This way, hidden elements stay hidden.