### PR TITLE
Added offsetHeight option

### DIFF
--- a/jquery.matchHeight.js
+++ b/jquery.matchHeight.js
@@ -70,7 +70,8 @@
             byRow: true,
             property: 'height',
             target: null,
-            remove: false
+            remove: false,
+            offsetHeight: 0
         };
 
         if (typeof options === 'object') {
@@ -239,6 +240,9 @@
                 // if target set, use the height of the target element
                 targetHeight = opts.target.outerHeight(false);
             }
+
+			// If there's an offsetHeight option, add it to the targetHeight
+            targetHeight = (opts.offsetHeight > 0) ? targetHeight + opts.offsetHeight : targetHeight;
 
             // iterate the row and apply the height to all elements
             $row.each(function(){


### PR DESCRIPTION
Added offsetHeight option to accommodate situations where the parent div is set to position:relative and and a child element is position:absolute. For example, a WordPress text widget with a button that needs to be aligned to the bottom of the parent div. offsetHeight should be a positive integer.