### PR TITLE
Use unminified version in Bower's "main" argument

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -6,7 +6,7 @@
         "Liam Brummitt <liam@brm.io> (http://brm.io/)"
     ],
     "description": "a more robust, responsive equal heights plugin for jQuery",
-    "main": "jquery.matchHeight-min.js",
+    "main": "jquery.matchHeight.js",
     "keywords": [
         "matchHeight",
         "equal",


### PR DESCRIPTION
According to Bower's [JSON spec](https://github.com/bower/bower.json-spec#main), you're not supposed to include minified files in the "main" argument.