### PR TITLE
Add [maintainScroll] option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,8 @@ The default options are:
         byRow: true,
         property: 'height',
         target: null,
-        remove: false
+        remove: false,
+        maintainScroll: false
     });
 
 Where:
@@ -77,6 +78,7 @@ Where:
 - `property` is the CSS property name to set (e.g. `'height'` or `'min-height'`)
 - `target` is an optional element to use instead of the element with maximum height
 - `remove` is `true` or `false` to remove previous bindings instead of applying new ones
+- `maintainScroll` is `true` or `false` to revert scroll before execute matchHeight
 
 ### Examples
 

--- a/jquery.matchHeight.js
+++ b/jquery.matchHeight.js
@@ -70,7 +70,8 @@
             byRow: true,
             property: 'height',
             target: null,
-            remove: false
+            remove: false,
+            maintainScroll: false
         };
 
         if (typeof options === 'object') {
@@ -268,6 +269,7 @@
         });
 
         // restore scroll position if enabled
+        matchHeight._maintainScroll = opts.maintainScroll;
         if (matchHeight._maintainScroll) {
             $(window).scrollTop((scrollTop / htmlHeight) * $('html').outerHeight(true));
         }


### PR DESCRIPTION
Hi, Thanks for useful plugin.

In my environment.
A image is loaded as lazy. So, I execute `matchHeight` each `scrollstop` event (which is original).

Then, scroll is deviated arbitrarily.

I found a code which already implemented.

By use that code. Scroll moving is stopped. ( It is good action for me.)
So, I want to use this option.

```
if (matchHeight._maintainScroll) {
            $(window).scrollTop((scrollTop / htmlHeight) * $('html').outerHeight(true));
        }
```