### PR TITLE
Improve row detection when cells contain floating contents

### DIFF
--- a/jquery.matchHeight.js
+++ b/jquery.matchHeight.js
@@ -188,7 +188,8 @@
                     'margin-bottom': '0',
                     'border-top-width': '0',
                     'border-bottom-width': '0',
-                    'height': '100px'
+                    'height': '100px',
+                    'overflow': 'hidden'
                 });
             });
 

--- a/test/page/test.css
+++ b/test/page/test.css
@@ -305,3 +305,18 @@ a.test-summary.has-failed {
     vertical-align: top;
     float: none;
 }
+
+/* test with-float */
+
+.with-float .item-0 {
+    float: none;
+    width: auto;
+}
+
+.with-float .item-0 div {
+    display: inline-block;
+    float: left;
+    width: 150px;
+    height: 150px;
+    background: green;
+}

--- a/test/page/test.html
+++ b/test/page/test.html
@@ -345,6 +345,37 @@
                     </div>
                 </div>
             </div>
+
+            <div class="items-container with-float">
+                <div class="item item-0">
+                    <div>floated</div>
+                    <p>some text</p>
+                    <p>some text</p>
+                    <p>some text</p>
+                    <p>some text</p>
+                    <p>some text</p>
+                </div>
+                <div class="item item-1">
+                    <p>some text</p>
+                    <p>some text</p>
+                    <p>some text</p>
+                    <p>some text</p>
+                </div>
+                <div class="item item-2">
+                    <p>some text</p>
+                    <p>some text</p>
+                    <p>some text</p>
+                    <p>some text</p>
+                </div>
+                <div class="item item-3">
+                    <p>some text</p>
+                </div>
+                <div class="item item-4">
+                    <p>some text</p>
+                    <p>some text</p>
+                    <p>some text</p>
+                </div>
+            </div>
         </div>
         <div id='results'></div>
     </body>


### PR DESCRIPTION
The row detection mechanism fixes the height of each cell to 100 pixels.
Cells that have floating contents can in some conditions remain taller
than 100 pixels, causing cells in the same row to be of unequal height.
Adding `overflow: hidden` fixes this problem.

Also see #88.
I did not update the minified file. Perhaps you could publish the script you use to minify matchHeight so contributors can use the same tool you use.