### PR TITLE
Turn on preservation of banner comment with license info.

### DIFF
--- a/dist/jquery.matchHeight-min.js
+++ b/dist/jquery.matchHeight-min.js
@@ -1,4 +1,4 @@
-/*
+/*!
 * jquery-match-height 0.7.0 by @liabru
 * http://brm.io/jquery-match-height/
 * License MIT

--- a/dist/jquery.matchHeight.js
+++ b/dist/jquery.matchHeight.js
@@ -1,4 +1,4 @@
-/**
+/*!
 * jquery-match-height 0.7.0 by @liabru
 * http://brm.io/jquery-match-height/
 * License: MIT

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -244,7 +244,7 @@ var serve = function(isTest) {
 };
 
 var banner = [
-  '/*',
+  '/*!',
   '* <%= build.name %> <%= build.version %> by @liabru',
   '* <%= build.homepage %>',
   '* License <%= build.license %>',

--- a/jquery.matchHeight.js
+++ b/jquery.matchHeight.js
@@ -1,4 +1,4 @@
-/**
+/*!
 * jquery-match-height master by @liabru
 * http://brm.io/jquery-match-height/
 * License: MIT


### PR DESCRIPTION
I’m not a lawyer but imo any third party code requires copyright with information about licence even in minified file, so this change is required to use TouchSwipe plugin as a part of another project or web app. Exclamation mark tells JavaScript tools which minify the code or concatenate files to leave the commented section intact.