### PR TITLE
bind/unbind deprecated in jQuery 3

### DIFF
--- a/jquery.matchHeight.js
+++ b/jquery.matchHeight.js
@@ -373,12 +373,12 @@
     $(matchHeight._applyDataApi);
 
     // update heights on load and resize events
-    $(window).bind('load', function(event) {
+    $(window).on('load', function(event) {
         matchHeight._update(false, event);
     });
 
     // throttled update heights on resize events
-    $(window).bind('resize orientationchange', function(event) {
+    $(window).on('resize orientationchange', function(event) {
         matchHeight._update(true, event);
     });
 


### PR DESCRIPTION
As of jQuery3, bind() and unbind() methods are deprecated. Replaced by on() and off() methods as required.
