### PR TITLE
Ability to exclude some elements' heights from calculations

### DIFF
--- a/dist/jquery.matchHeight.js
+++ b/dist/jquery.matchHeight.js
@@ -235,6 +235,10 @@
                         style = $that.attr('style'),
                         display = $that.css('display');
 
+                    if( $that.hasClass('mh-ignore-height') ) {
+                      return;
+                    }
+
                     // temporarily force a usable display value
                     if (display !== 'inline-block' && display !== 'flex' && display !== 'inline-flex') {
                         display = 'block';


### PR DESCRIPTION
As per my comment in issues.
Any element with class **mh-ignore-height** will be ignored when looking for the highest element.