### PR TITLE
Fix invisible items on item rows

### DIFF
--- a/jquery.matchHeight.js
+++ b/jquery.matchHeight.js
@@ -52,6 +52,11 @@
                 top = $that.offset().top - _parse($that.css('margin-top')),
                 lastRow = rows.length > 0 ? rows[rows.length - 1] : null;
 
+            // only take visible items into account
+            if (!$that.is(':visible')) {
+                return true;
+            }
+
             if (lastRow === null) {
                 // first item on the row, so just push it
                 rows.push($that);


### PR DESCRIPTION
When there are invisible items on some rows, the top positions are sometimes calculated incorrectly.

This happens in specific cases where we want to show specific items on desktop, specific items on tablet and specific items on mobile.

For example, the structure can be as follows:

Desktop
[ item 1 ]   [ item 2 ]   [ item 3 ]

Tablet
[ item 1 ]   [ item 2 ]
[ item 4 ]   [ item 5 ]

Mobile
[ item 1 ]
[ item 2 ]
[ item 3 ]
[ item 4 ]
[ item 5 ]

As shown, in this case the following applies:

- On desktop, items 4 and 5 are hidden
- On tablet, item 3 is hidden (which is in the middle of items 2 and 4)

This causes the second row to be calculated incorrectly in specific situations on table.